### PR TITLE
Fix positioning of dropdown

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -262,7 +262,7 @@ export default class ModalDropdown extends Component {
     const showInLeft = rightSpace >= this._buttonFrame.x;
     const positionStyle = {
       height: dropdownHeight,
-      top: !showInBottom
+      top: showInBottom
         ? this._buttonFrame.y + this._buttonFrame.h
         : Math.max(0, this._buttonFrame.y - dropdownHeight),
     };

--- a/example/ModalDropdown.js
+++ b/example/ModalDropdown.js
@@ -262,7 +262,7 @@ export default class ModalDropdown extends Component {
     const showInLeft = rightSpace >= this._buttonFrame.x;
     const positionStyle = {
       height: dropdownHeight,
-      top: !showInBottom
+      top: showInBottom
         ? this._buttonFrame.y + this._buttonFrame.h
         : Math.max(0, this._buttonFrame.y - dropdownHeight),
     };


### PR DESCRIPTION
- there was a swtich in calculation for `top` with an older PR:
https://github.com/siemiatj/react-native-modal-dropdown-legacy/pull/1
- this lets the dropdown opens to the wrong position (top/bottom)
- reverted that change in core and in example project
- tested in example app

Resolves #1