### PR TITLE
feat(search): added possibility for search

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -11,7 +11,8 @@ import {
   Modal,
   ActivityIndicator,
   FlatList,
-  Platform
+  Platform,
+  TextInput
 } from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -34,6 +35,17 @@ export default class ModalDropdown extends Component {
     animated: PropTypes.bool,
     showsVerticalScrollIndicator: PropTypes.bool,
     keyboardShouldPersistTaps: PropTypes.string,
+    showSearch: PropTypes.bool,
+    renderSearch: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object,
+    ]),
+    searchInputStyle: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.object,
+      PropTypes.array,
+    ]),
+    searchPlaceholder: PropTypes.string,
     style: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.object,
@@ -59,7 +71,6 @@ export default class ModalDropdown extends Component {
       PropTypes.object,
       PropTypes.array,
     ]),
-    dropdownTextProps: PropTypes.object,
     adjustFrame: PropTypes.func,
     renderRow: PropTypes.func,
     renderRowComponent: PropTypes.oneOfType([
@@ -88,6 +99,8 @@ export default class ModalDropdown extends Component {
     animated: true,
     showsVerticalScrollIndicator: true,
     keyboardShouldPersistTaps: 'never',
+    showSearch: false,
+    searchPlaceholder: "Search",
     renderRowComponent: Platform.OS === 'ios' ? TouchableOpacity : TouchableHighlight,
     renderButtonComponent: TouchableOpacity,
   };
@@ -103,6 +116,8 @@ export default class ModalDropdown extends Component {
       showDropdown: false,
       buttonText: props.defaultValue,
       selectedIndex: props.defaultIndex,
+      options: props.options,
+      searchValue: '',
     };
   }
 
@@ -330,8 +345,8 @@ export default class ModalDropdown extends Component {
       renderSeparator,
       showsVerticalScrollIndicator,
       keyboardShouldPersistTaps,
-      options,
     } = this.props;
+    const { options } = this.state;
 
     return (
       <FlatList
@@ -344,9 +359,48 @@ export default class ModalDropdown extends Component {
         automaticallyAdjustContentInsets={false}
         showsVerticalScrollIndicator={showsVerticalScrollIndicator}
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+        ListHeaderComponent={this._renderSearchInput}
       />
     );
   }
+
+  _renderSearchInput = () => {
+    const {
+      showSearch,
+      renderSearch,
+      searchInputStyle,
+      searchPlaceholder,
+      options: initialOptions,
+    } = this.props;
+
+    if (!showSearch) return null;
+    if (renderSearch) return renderSearch;
+
+    const { buttonText, searchValue } = this.state;
+
+    return (
+      <TextInput
+        style={[styles.searchInput, searchInputStyle]}
+        onChangeText={(text) => {
+          let filteredOptions = initialOptions;
+
+          if (text) {
+            filteredOptions = initialOptions.filter((option) =>
+              option.toLowerCase().includes(text.toLowerCase().trim())
+            );
+          }
+
+          this.setState({
+            searchValue: text,
+            options: filteredOptions,
+            selectedIndex: filteredOptions.indexOf(buttonText)
+          })
+        }}
+        value={searchValue}
+        placeholder={searchPlaceholder}
+      />
+    );
+  };
 
   _renderItem = ({ item, index, separators }) => {
     const {
@@ -463,4 +517,11 @@ const styles = StyleSheet.create({
     height: StyleSheet.hairlineWidth,
     backgroundColor: 'lightgray',
   },
+  searchInput: {
+    borderColor: 'gray',
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 11,
+    paddingHorizontal: 6,
+    paddingVertical: 10,
+  }
 });

--- a/expo-example/App.js
+++ b/expo-example/App.js
@@ -13,6 +13,7 @@ import {
   TouchableOpacity,
   TouchableHighlight,
   ScrollView,
+  TextInput,
 } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
@@ -31,12 +32,15 @@ const DEMO_OPTIONS_2 = [
   {"name": "Ian", "age": 20},
   {"name": "Phil", "age": 24},
 ];
+const DEMO_OPTIONS_7 = ['a option 1', 'b option 2', 'c option 3', 'd option 4', 'e option 5', 'f option 6', 'g option 7', 'h option 8', 'i option 9', 'j option 10'];
 
 class App extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
+      dropdown_2_options: DEMO_OPTIONS_2,
+      dropdown_2_searchValue: '',
       dropdown_4_options: [],
       dropdown_4_defaultValue: 'loading...',
       dropdown_6_icon_heart: true,
@@ -45,6 +49,7 @@ class App extends Component {
 
   render() {
     const dropdown_6_icon = this.state.dropdown_6_icon_heart ? require('./images/heart.png') : require('./images/flower.png');
+
     return (
       <View style={styles.container}>
         <StatusBar style="auto" />
@@ -81,6 +86,40 @@ class App extends Component {
                 select Rex
               </Text>
             </TouchableOpacity>
+            <Text></Text>
+            <Text>with search (not rerendering the options yet):</Text>
+            <ModalDropdown ref="dropdown_2"
+                           style={styles.dropdown_2}
+                           textStyle={styles.dropdown_2_text}
+                           dropdownStyle={styles.dropdown_2_dropdown}
+                           options={this.state.dropdown_2_options}
+                           renderButtonText={(rowData) => this._dropdown_2_renderButtonText(rowData)}
+                           renderRow={this._dropdown_2_renderRow.bind(this)}
+                           renderRowComponent={TouchableHighlight}
+                           renderSeparator={(sectionID, rowID, adjacentRowHighlighted) => this._dropdown_2_renderSeparator(sectionID, rowID, adjacentRowHighlighted)}
+                           showSearch
+                           renderSearch={
+                            <TextInput
+                              style={styles.searchInput}
+                              onChangeText={(text) => {
+                                let filteredOptions = DEMO_OPTIONS_2;
+
+                                if (text) {
+                                  filteredOptions = DEMO_OPTIONS_2.filter((option) =>
+                                    option.name.toLowerCase().includes(text.toLowerCase().trim())
+                                  );
+                                }
+
+                                this.setState({
+                                  dropdown_2_searchValue: text,
+                                  dropdown_2_options: filteredOptions
+                                })
+                              }}
+                              value={this.state.dropdown_2_searchValue}
+                              placeholder="Search"
+                            />
+                           }
+            />
           </View>
         </View>
         <View style={styles.row}>
@@ -100,6 +139,16 @@ class App extends Component {
                            dropdownTextHighlightStyle={styles.dropdown_3_dropdownTextHighlightStyle}
             />
           </ScrollView>
+        </View>
+        <View style={styles.row}>
+          <View style={[styles.cell, {alignItems: 'center'}]}>
+            <Text>Search example:</Text>
+            <ModalDropdown ref={el => this._dropdown_7 = el}
+                           style={styles.dropdown_7}
+                           options={DEMO_OPTIONS_7}
+                           showSearch
+            />
+          </View>
         </View>
         <View style={styles.row}>
           <View style={[styles.cell, {justifyContent: 'flex-end'}]}>
@@ -343,6 +392,19 @@ const styles = StyleSheet.create({
   dropdown_6_image: {
     width: 40,
     height: 40,
+  },
+  dropdown_7: {
+    width: 150,
+    borderColor: 'lightgray',
+    borderWidth: 1,
+    borderRadius: 1,
+  },
+  searchInput: {
+    borderColor: 'gray',
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 11,
+    paddingHorizontal: 6,
+    paddingVertical: 10,
   },
 });
 

--- a/expo-example/ModalDropdown.js
+++ b/expo-example/ModalDropdown.js
@@ -11,7 +11,8 @@ import {
   Modal,
   ActivityIndicator,
   FlatList,
-  Platform
+  Platform,
+  TextInput
 } from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -34,6 +35,17 @@ export default class ModalDropdown extends Component {
     animated: PropTypes.bool,
     showsVerticalScrollIndicator: PropTypes.bool,
     keyboardShouldPersistTaps: PropTypes.string,
+    showSearch: PropTypes.bool,
+    renderSearch: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object,
+    ]),
+    searchInputStyle: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.object,
+      PropTypes.array,
+    ]),
+    searchPlaceholder: PropTypes.string,
     style: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.object,
@@ -87,6 +99,8 @@ export default class ModalDropdown extends Component {
     animated: true,
     showsVerticalScrollIndicator: true,
     keyboardShouldPersistTaps: 'never',
+    showSearch: false,
+    searchPlaceholder: "Search",
     renderRowComponent: Platform.OS === 'ios' ? TouchableOpacity : TouchableHighlight,
     renderButtonComponent: TouchableOpacity,
   };
@@ -102,6 +116,8 @@ export default class ModalDropdown extends Component {
       showDropdown: false,
       buttonText: props.defaultValue,
       selectedIndex: props.defaultIndex,
+      options: props.options,
+      searchValue: '',
     };
   }
 
@@ -329,8 +345,8 @@ export default class ModalDropdown extends Component {
       renderSeparator,
       showsVerticalScrollIndicator,
       keyboardShouldPersistTaps,
-      options,
     } = this.props;
+    const { options } = this.state;
 
     return (
       <FlatList
@@ -343,9 +359,48 @@ export default class ModalDropdown extends Component {
         automaticallyAdjustContentInsets={false}
         showsVerticalScrollIndicator={showsVerticalScrollIndicator}
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+        ListHeaderComponent={this._renderSearchInput}
       />
     );
   }
+
+  _renderSearchInput = () => {
+    const {
+      showSearch,
+      renderSearch,
+      searchInputStyle,
+      searchPlaceholder,
+      options: initialOptions,
+    } = this.props;
+
+    if (!showSearch) return null;
+    if (renderSearch) return renderSearch;
+
+    const { buttonText, searchValue } = this.state;
+
+    return (
+      <TextInput
+        style={[styles.searchInput, searchInputStyle]}
+        onChangeText={(text) => {
+          let filteredOptions = initialOptions;
+
+          if (text) {
+            filteredOptions = initialOptions.filter((option) =>
+              option.toLowerCase().includes(text.toLowerCase().trim())
+            );
+          }
+
+          this.setState({
+            searchValue: text,
+            options: filteredOptions,
+            selectedIndex: filteredOptions.indexOf(buttonText)
+          })
+        }}
+        value={searchValue}
+        placeholder={searchPlaceholder}
+      />
+    );
+  };
 
   _renderItem = ({ item, index, separators }) => {
     const {
@@ -462,4 +517,11 @@ const styles = StyleSheet.create({
     height: StyleSheet.hairlineWidth,
     backgroundColor: 'lightgray',
   },
+  searchInput: {
+    borderColor: 'gray',
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 11,
+    paddingHorizontal: 6,
+    paddingVertical: 10,
+  }
 });


### PR DESCRIPTION
It is a first version of search input. I already use it in my project. It works for array of strings `options`. I added the ability for a custom list header component to render for the search per `renderSearch` prop. Sadly in the examples it is not fully working until now.

_Issue_: https://github.com/siemiatj/react-native-modal-dropdown/issues/2

_TODO_:
- [ ] update README
- [ ] fix for re-rendering custom `renderSearch` components

_Commit_:
- added list header component which can have a search or random
  component
- setting `showSearch` to true will render the list header with a search,
  that works with string arrays as options
  - one can add custom styles for the input per `searchInputStyle` prop
  - if there is an object with keys one need to provide a `renderSearch`
    function with an individual search and logic
- added a search example to the expo examples screen
  - the custom search for example 2 with random rows is not working
    correctly, as the options will not re-render even if the state object
    for the options changes