### PR TITLE
fix: Fixed a warning when options are loading

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -29,7 +29,7 @@ export default class ModalDropdown extends Component {
     scrollEnabled: PropTypes.bool,
     defaultIndex: PropTypes.number,
     defaultValue: PropTypes.string,
-    options: PropTypes.array.isRequired,
+    options: PropTypes.array,
     accessible: PropTypes.bool,
     animated: PropTypes.bool,
     isFullWidth: PropTypes.bool,


### PR DESCRIPTION
Removed the isRequired check for options. It doesn't make sense because when options={null}, the component displays a loading indicator.