### PR TITLE
Add testIDs for E2E testing of modal drop down buttons

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -396,6 +396,7 @@ export default class ModalDropdown extends Component {
           highlighted && styles.highlightedRowText,
           highlighted && dropdownTextHighlightStyle,
         ]}
+        testID={item}
         {...dropdownTextProps}
       >
         {value}


### PR DESCRIPTION
Hello!

Making this PR to add testIDs for dropdown elements. This will enable our (and others) QA team to access these buttons in their automated testing.

Let me know if you'd like me to make any changes or if you have a better approach.